### PR TITLE
Add TypeScript web bindings support via uniffi-bindgen-react-native

### DIFF
--- a/.justfile
+++ b/.justfile
@@ -1,6 +1,7 @@
 FAT_SIMULATOR_LIB_DIR := "target" / "ios-simulator-fat" / "release"
 LIBNAME := "janus_gateway"
 MODULENAME := "JanusGateway"
+TYPESCRIPT_OUT_DIR := "typescript"
 
 VERSION := `cargo metadata --format-version 1 | jq -r '.packages[] | select(.name=="rslib") .version'`
 SHORTCOMMIT := `git rev-parse --short HEAD`
@@ -94,6 +95,29 @@ apple-clean:
 	@rm -rf target/uniffi-xcframework-staging
 	@rm -rf {{FAT_SIMULATOR_LIB_DIR}}
 
+# Build TypeScript (WASM) bindings for web. Requires uniffi-bindgen-react-native: npm install -g uniffi-bindgen-react-native
+[group: 'web']
+web: web-clean web-build web-generate-ts
+
+# Build the Rust library as WebAssembly
+[group: 'web']
+web-build:
+	@echo "Building Rust lib for WebAssembly"
+	@ubrn build web
+
+# Generate TypeScript bindings from the built WASM library
+[group: 'web']
+web-generate-ts:
+	@echo "Generating TypeScript bindings for web"
+	@ubrn generate ts
+
+# Clean up the web build artifacts
+[group: 'web']
+web-clean:
+	@echo "Cleaning web build artifacts"
+	@rm -rf {{TYPESCRIPT_OUT_DIR}}
+	@rm -rf rust_modules
+
 # Build library for android. Pass `-r` to build release version
 [group: 'android']
 android release="": android-clean (android-build release)
@@ -117,8 +141,8 @@ android-build release="":
 	fi
 
 [group: 'utils']
-[confirm("Running this recipe will delete all cached file for Apple, Android, and Rust. Continue? [y/yes] [n/no]")]
-clean-all: apple-clean android-clean
+[confirm("Running this recipe will delete all cached file for Apple, Android, Web, and Rust. Continue? [y/yes] [n/no]")]
+clean-all: apple-clean android-clean web-clean
 	@cargo clean
 
 # Updates the janus-mobile-sdk version inside rslib/Cargo.toml and Package.swift

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -24,4 +24,7 @@ targets = [
     "i686-linux-android",
     "aarch64-linux-android",
     "x86_64-linux-android",
+
+    # Web (WASM)
+    "wasm32-unknown-unknown",
 ]

--- a/ubrn.config.yaml
+++ b/ubrn.config.yaml
@@ -1,0 +1,13 @@
+---
+rust:
+  manifestPath: rslib/Cargo.toml
+
+web:
+  workspace: false
+  target: web
+  wasmCrateName: janus-gateway-web
+  tsBindings: typescript/bindings
+
+bindings:
+  ts: typescript/bindings
+  uniffiToml: rslib/uniffi.toml


### PR DESCRIPTION
- Add ubrn.config.yaml with web/WASM configuration pointing to rslib
- Add wasm32-unknown-unknown target to rust-toolchain.toml
- Add web group recipes to .justfile:
  - `web`: full pipeline (clean + build + generate)
  - `web-build`: compile Rust lib to WebAssembly via `ubrn build web`
  - `web-generate-ts`: generate TypeScript bindings via `ubrn generate ts`
  - `web-clean`: remove typescript/ and rust_modules/ build artifacts
- Include web-clean in clean-all recipe

Requires uniffi-bindgen-react-native npm package:

```
npm install -g uniffi-bindgen-react-native
```