### PR TITLE
feat: optimize lib size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,3 @@
+# Pass -dead_strip to the Apple linker for additional unused-symbol removal.
+[target.'cfg(target_vendor = "apple")']
+rustflags = ["-C", "link-arg=-dead_strip"]

--- a/.justfile
+++ b/.justfile
@@ -7,6 +7,15 @@ SHORTCOMMIT := `git rev-parse --short HEAD`
 
 LATEST_TAG := `git tag --sort=-version:refname | head -n 1 2>/dev/null || echo "0.0.0"`
 
+# `-Zbuild-std` recompiles `std` with `panic=immediate-abort` (matching the
+# crate's `panic = "abort"` profile), dropping unwinding/backtrace/formatting
+# machinery that bloats the static archive. Requires nightly + `rust-src`, so
+# these recipes invoke `cargo +nightly` explicitly; the rest of the project
+# stays on stable. `-dead_strip` mirrors .cargo/config.toml (env RUSTFLAGS
+# overrides the config file, so it must be repeated here).
+BUILD_STD_FLAGS := "-Z build-std=std,panic_abort"
+BUILD_STD_RUSTFLAGS := "-Zunstable-options -Cpanic=immediate-abort -Clink-arg=-dead_strip"
+
 # Displays the available recipes
 help:
 	@just -l
@@ -25,10 +34,10 @@ apple-build: apple-build-rslib apple-create-fat-simulator-lib
 [private]
 [macos]
 apple-build-rslib:
-	@echo "Building Rust lib"
-	@cargo build --lib --release --target x86_64-apple-ios
-	@cargo build --lib --release --target aarch64-apple-ios-sim
-	@cargo build --lib --release --target aarch64-apple-ios
+	@echo "Building Rust lib (build-std, panic=immediate-abort)"
+	RUSTFLAGS="{{BUILD_STD_RUSTFLAGS}}" cargo +nightly build --lib --release --target x86_64-apple-ios {{BUILD_STD_FLAGS}}
+	RUSTFLAGS="{{BUILD_STD_RUSTFLAGS}}" cargo +nightly build --lib --release --target aarch64-apple-ios-sim {{BUILD_STD_FLAGS}}
+	RUSTFLAGS="{{BUILD_STD_RUSTFLAGS}}" cargo +nightly build --lib --release --target aarch64-apple-ios {{BUILD_STD_FLAGS}}
 
 # Combines two static libs to create the simulator fat lib
 [private]

--- a/android/janus/build.gradle.kts
+++ b/android/janus/build.gradle.kts
@@ -53,6 +53,22 @@ dependencies {
 cargoNdk {
     module = ".."
     librariesNames = arrayListOf("libjanus_gateway.so")
+
+    // Recompile `std` with `panic=immediate-abort` for the release `.so` only,
+    // mirroring the Apple build-std recipe in `.justfile`. `-Zbuild-std` needs a
+    // nightly cargo, selected via RUSTUP_TOOLCHAIN (rustup honours it over
+    // rust-toolchain.toml). Debug builds stay on stable for fast iteration.
+    // The "release"/"debug" build types are pre-created by the plugin, so we
+    // configure the existing one rather than creating a new one.
+    buildTypes {
+        getByName("release") {
+            extraCargoBuildArguments = arrayListOf("-Z", "build-std=std,panic_abort")
+            extraCargoEnv = mapOf(
+                "RUSTUP_TOOLCHAIN" to "nightly",
+                "RUSTFLAGS" to "-Zunstable-options -Cpanic=immediate-abort"
+            )
+        }
+    }
 }
 
 afterEvaluate {

--- a/rslib/Cargo.toml
+++ b/rslib/Cargo.toml
@@ -13,9 +13,11 @@ crate-type = ["cdylib", "staticlib", "lib"]
 # didn't work. https://github.com/rust-lang/cargo/issues/15262
 [profile.release]
 opt-level = "z"
-lto = "thin"
+lto = "fat"
+codegen-units = 1
 panic = "abort"
 strip = "symbols"
+overflow-checks = false
 
 [dependencies]
 log = "0.4.29"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -8,7 +8,12 @@
 
 [toolchain]
 channel = "stable"
-components = ["clippy", "rustfmt"]
+# `rust-src` is required by the `-Zbuild-std` release builds (see `.justfile` for
+# Apple and `android/janus/build.gradle.kts` for Android), which recompile `std`
+# with `panic=immediate-abort` to shrink the shipped libs. Those builds invoke
+# nightly explicitly (`cargo +nightly` / `RUSTUP_TOOLCHAIN=nightly`); the rest of
+# the project (dev, CI, debug) stays on stable.
+components = ["clippy", "rustfmt", "rust-src"]
 targets = [
     # iOS
     "aarch64-apple-ios",


### PR DESCRIPTION
Aggressive size optimizations by using fat `lto`, removed overflow checks, and smaller codegen unit, and compile `std` to tree shake it so we only include used std mods